### PR TITLE
Updates to Compose 1.2.0-alpha03

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -17,7 +17,7 @@ object Libs {
     }
 
     object Compose {
-        const val version = "1.2.0-alpha02"
+        const val version = "1.2.0-alpha03"
         const val activity = "androidx.activity:activity-compose:1.4.0"
         const val constraintlayout =
             "androidx.constraintlayout:constraintlayout-compose:1.0.0"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -48,6 +48,7 @@ android {
 dependencies {
     implementation Libs.Kotlin.stdlib
     implementation Libs.Compose.animation
+    implementation Libs.Compose.runtime
     implementation Libs.Compose.ui
 
     // ======================


### PR DESCRIPTION
- https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.2.0-alpha03
- 'androidx.compose.runtime' is added in ':core' module, because of tracing API.