### PR TITLE
Introduce `circularReveal` modifier

### DIFF
--- a/android/src/main/java/soup/compose/material/motion/sample/ui/HomeScreen.kt
+++ b/android/src/main/java/soup/compose/material/motion/sample/ui/HomeScreen.kt
@@ -77,6 +77,11 @@ private data class Category(
                         description = "HoldScreen",
                         destination = Destination.Hold
                     ),
+                    Demo(
+                        title = "CircularReveal",
+                        description = "CircularRevealScreen",
+                        destination = Destination.CircularReveal
+                    ),
                 )
             ),
             Category(

--- a/android/src/main/java/soup/compose/material/motion/sample/ui/NavGraph.kt
+++ b/android/src/main/java/soup/compose/material/motion/sample/ui/NavGraph.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import soup.compose.material.motion.navigation.MaterialMotionNavHost
 import soup.compose.material.motion.navigation.composable
 import soup.compose.material.motion.navigation.rememberMaterialMotionNavController
+import soup.compose.material.motion.sample.ui.circularreveal.CircularRevealScreen
 import soup.compose.material.motion.sample.ui.demo.DemoScreen
 import soup.compose.material.motion.sample.ui.material.elevationscale.MaterialElevationScaleScreen
 import soup.compose.material.motion.sample.ui.material.fade.MaterialFadeScreen
@@ -38,6 +39,7 @@ enum class Destination(val route: String) {
     MaterialFade("material_fade"),
     MaterialElevationScale("material_elevation_scale"),
     Hold("hold"),
+    CircularReveal("circular_reveal"),
     Navigation("navigation"),
 }
 
@@ -84,6 +86,9 @@ fun NavGraph(
         }
         composable(Destination.Hold.route) {
             HoldScreen(upPress = upPress)
+        }
+        composable(Destination.CircularReveal.route) {
+            CircularRevealScreen(upPress = upPress)
         }
 
         /* Navigation */

--- a/android/src/main/java/soup/compose/material/motion/sample/ui/circularreveal/CircularRevealScreen.kt
+++ b/android/src/main/java/soup/compose/material/motion/sample/ui/circularreveal/CircularRevealScreen.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package soup.compose.material.motion.sample.ui.circularreveal
+
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import soup.compose.material.motion.circularReveal
+import soup.compose.material.motion.sample.ui.common.DefaultScaffold
+import soup.compose.material.motion.sample.ui.theme.SampleTheme
+
+private data class Position(
+    val label: String,
+    val alignment: Alignment,
+    val center: Offset,
+)
+
+private val POSITIONS = listOf(
+    Position(
+        label = "TopStart",
+        alignment = Alignment.TopStart,
+        center = Offset(0f, 0f),
+    ),
+    Position(
+        label = "TopCenter",
+        alignment = Alignment.TopCenter,
+        center = Offset(0.5f, 0f),
+    ),
+    Position(
+        label = "TopEnd",
+        alignment = Alignment.TopEnd,
+        center = Offset(1f, 0f),
+    ),
+    Position(
+        label = "CenterStart",
+        alignment = Alignment.CenterStart,
+        center = Offset(0f, 0.5f),
+    ),
+    Position(
+        label = "Center",
+        alignment = Alignment.Center,
+        center = Offset(0.5f, 0.5f),
+    ),
+    Position(
+        label = "CenterEnd",
+        alignment = Alignment.CenterEnd,
+        center = Offset(1f, 0.5f),
+    ),
+    Position(
+        label = "BottomStart",
+        alignment = Alignment.BottomStart,
+        center = Offset(0f, 1f),
+    ),
+    Position(
+        label = "BottomCenter",
+        alignment = Alignment.BottomCenter,
+        center = Offset(0.5f, 1f),
+    ),
+    Position(
+        label = "BottomEnd",
+        alignment = Alignment.BottomEnd,
+        center = Offset(1f, 1f),
+    ),
+)
+
+private data class State(
+    val visible: Boolean,
+    val center: Offset,
+)
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun CircularRevealScreen(upPress: () -> Unit) {
+    val (state, onStateChanged) = remember {
+        mutableStateOf(State(false, Offset.Zero))
+    }
+    BackHandler {
+        if (state.visible) {
+            onStateChanged(state.copy(visible = false))
+        } else {
+            upPress()
+        }
+    }
+    DefaultScaffold(upPress = upPress) { innerPadding ->
+        Surface(modifier = Modifier.padding(innerPadding)) {
+            Box(modifier = Modifier.fillMaxSize().padding(all = 16.dp)) {
+                POSITIONS.forEach {
+                    TextButton(
+                        onClick = { onStateChanged(State(visible = true, center = it.center)) },
+                        modifier = Modifier.align(it.alignment)
+                    ) {
+                        Text(text = it.label)
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .circularReveal(
+                        visible = state.visible,
+                        center = { fullSize ->
+                            Offset(
+                                x = state.center.x * fullSize.width,
+                                y = state.center.y * fullSize.height,
+                            )
+                        },
+                    )
+                    .fillMaxSize()
+                    .background(color = MaterialTheme.colors.secondary)
+            ) {
+                Button(
+                    onClick = { onStateChanged(state.copy(visible = false)) },
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    Text("Close")
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Light", showBackground = true)
+@Preview(name = "Dark", showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun DefaultPreview() {
+    SampleTheme {
+        CircularRevealScreen(upPress = {})
+    }
+}

--- a/core/api/current.api
+++ b/core/api/current.api
@@ -1,6 +1,10 @@
 // Signature format: 4.0
 package soup.compose.material.motion {
 
+  public final class CircularRevealKt {
+    method @androidx.compose.animation.ExperimentalAnimationApi public static androidx.compose.ui.Modifier circularReveal(androidx.compose.ui.Modifier, boolean visible, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.geometry.Size,androidx.compose.ui.geometry.Offset> center, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.core.Transition.Segment<java.lang.Boolean>,? extends androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float>> transitionSpec);
+  }
+
   @androidx.compose.runtime.Immutable public final class EnterMotionSpec {
     ctor public EnterMotionSpec(kotlin.jvm.functions.Function2<? super java.lang.Boolean,? super androidx.compose.ui.unit.Density,? extends androidx.compose.animation.EnterTransition> transition);
     method public kotlin.jvm.functions.Function2<java.lang.Boolean,androidx.compose.ui.unit.Density,androidx.compose.animation.EnterTransition> component1();

--- a/core/src/main/java/soup/compose/material/motion/CircularReveal.kt
+++ b/core/src/main/java/soup/compose/material/motion/CircularReveal.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 SOUP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package soup.compose.material.motion
+
+import android.graphics.Path
+import androidx.annotation.FloatRange
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.geometry.takeOrElse
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.hypot
+
+/**
+ * Draws circular reveal animation.
+ *
+ * @param visible whether the circular reveal animation should be visible or not.
+ * @param center The x,y coordinates at which the circular reveal animation starts or ends.
+ * If undefined or [Offset.Unspecified], the x,y coordinates will be the center of [Size].
+ * @param transitionSpec The transition spec to use when clipping the screen.
+ * The boolean parameter defined for the transition is [visible].
+ */
+@ExperimentalAnimationApi
+public fun Modifier.circularReveal(
+    visible: Boolean,
+    center: (fullSize: Size) -> Offset = { Offset.Unspecified },
+    transitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "circularReveal"
+        properties["visible"] = visible
+        properties["center"] = center
+    }
+) {
+    val transition = updateTransition(targetState = visible, label = "circularReveal")
+    val progress: Float by transition.animateFloat(
+        transitionSpec = transitionSpec,
+        label = "progress",
+        targetValueByState = { circularRevealVisible -> if (circularRevealVisible) 1f else 0f }
+    )
+    graphicsLayer {
+        clip = progress < 1f
+        shape = CircularRevealShape(
+            progress = progress,
+            center = center,
+        )
+    }
+}
+
+private class CircularRevealShape(
+    @FloatRange(from = 0.0, to = 1.0)
+    private val progress: Float,
+    private val center: (fullSize: Size) -> Offset = { Offset.Unspecified },
+) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density,
+    ): Outline {
+        val center: Offset = center(size).takeOrElse { size.center }
+        val radius: Float = size.getLongestRadiusFrom(center) * progress
+        val path: Path = Path().also {
+            it.addCircle(center.x, center.y, radius, Path.Direction.CW)
+        }
+        return Outline.Generic(path = path.asComposePath())
+    }
+
+    private fun Size.getLongestRadiusFrom(center: Offset): Float {
+        val topLeft: Float = hypot(center.x, center.y)
+        val topRight: Float = hypot(width - center.x, center.y)
+        val bottomLeft: Float = hypot(center.x, height - center.y)
+        val bottomRight: Float = hypot(width - center.x, height - center.y)
+        return maxOf(topLeft, topRight, bottomLeft, bottomRight)
+    }
+}


### PR DESCRIPTION

### Example Codes
```kt
var visible: Boolean by remember { mutableStateOf(false) }
Box(
    modifier = Modifier.circularReveal(
        visible = visible,
        center = { fullSize ->
            Offset(x = 1f * fullSize.width, y = 0f * fullSize.height) // TopRight
        },
    )
) { ... }
```

https://user-images.githubusercontent.com/3405740/176953579-4704985a-706a-4681-b41d-123067c2719f.mp4

## References
- https://gist.github.com/darvld/eb3844474baf2f3fc6d3ab44a4b4b5f8
- https://gist.github.com/ErfanSn/f3283d2b22b78fe4ad9b0791c4370e2c